### PR TITLE
Fix ext-debian.sh

### DIFF
--- a/.github/scripts/ext-debian.sh
+++ b/.github/scripts/ext-debian.sh
@@ -43,7 +43,7 @@ stage_source() {
   cd "$PKG_BUILD_DIR" || exit
 
   echo "Generating source tarball from git repo."
-  tar cfzv --force-local $debian_package_name\_${debian_version}.orig.tar.gz --exclude .git\* --exclude /debian $PACKAGE_NAME/../$PACKAGE_NAME
+  tar cfzv $debian_package_name\_${debian_version}.orig.tar.gz --force-local --exclude .git\* --exclude /debian $PACKAGE_NAME/../$PACKAGE_NAME
 
   popd
 }


### PR DESCRIPTION
**Description**
`tar` option style syntax should get the option arguments before long-style-options. In its current form, it would create a tar with name as `--force-local` which seems wrong.

**Test**
- `./local-build.sh ../.. ext-debian.sh regolith-i3status-rust https://github.com/gogsbread/regolith-i3status-rust.git debian_source focal`