### PR TITLE
Add experimental stage to rebuild r2.1

### DIFF
--- a/.github/workflows/build-deb-v4.yml
+++ b/.github/workflows/build-deb-v4.yml
@@ -12,11 +12,17 @@ jobs:
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
-        stage: [experimental, unstable, testing, release]
+        stage: [experimental, unstable, testing, release, release-2_1]
         distro-codename: [ubuntu-focal-amd64, ubuntu-focal-arm64, ubuntu-jammy-amd64, ubuntu-jammy-arm64, ubuntu-kinetic-amd64, ubuntu-kinetic-arm64, debian-bullseye-amd64, debian-bullseye-arm64, debian-testing-amd64]
         exclude:
           - stage: release
             distro-codename: debian-testing-amd64
+          - stage: release
+            distro-codename: debian-testing-arm64
+          - stage: release-2_1
+            distro-codename: debian-testing-amd64
+          - stage: release-2_1
+            distro-codename: debian-testing-arm64
           - stage: experimental
             distro-codename: ubuntu-kinetic-arm64
         include:

--- a/stage/release-2_1/debian/bullseye/amd64/setup.sh
+++ b/stage/release-2_1/debian/bullseye/amd64/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This PPA adds nececessary backports for debbuild helper 13
+sudo apt install -y software-properties-common
+sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/release-2_1/debian/bullseye/package-model.json
+++ b/stage/release-2_1/debian/bullseye/package-model.json
@@ -1,0 +1,16 @@
+{
+  "packages": {
+    "regolith-desktop": {
+      "source": "https://github.com/regolith-linux/regolith-desktop.git",
+      "ref": "r2_1-debian-bullseye"
+    },
+    "xcb-util": {
+      "source": "https://git.launchpad.net/ubuntu/+source/xcb-util",
+      "ref": "applied/ubuntu/groovy"
+    },
+    "regolith-session": {
+      "source": "https://github.com/regolith-linux/regolith-session.git",
+      "ref": "r2_1-debian-bullseye"
+    }
+  }
+}

--- a/stage/release-2_1/package-model.json
+++ b/stage/release-2_1/package-model.json
@@ -1,0 +1,176 @@
+{
+  "packages": {
+    "regolith-system-ubuntu": {
+      "source": "https://github.com/regolith-linux/regolith-system-ubuntu.git",
+      "ref": "r2_1"
+    },
+    "regolith-lightdm-config": {
+      "source": "https://github.com/regolith-linux/regolith-lightdm-config.git",
+      "ref": "r2_1"
+    },
+    "regolith-session": {
+      "source": "https://github.com/regolith-linux/regolith-session.git",
+      "ref": "r2_1"
+    },
+    "i3-snapshot": {
+      "source": "https://github.com/regolith-linux/i3-snapshot.git",
+      "ref": "r2_1"
+    },
+    "python3-i3ipc": {
+      "source": "https://github.com/regolith-linux/python3-i3ipc",
+      "ref": "r2_1"
+    },
+    "fonts-jetbrains-mono": {
+      "source": "https://github.com/regolith-linux/fonts-jetbrains-mono.git",
+      "ref": "r2_1"
+    },
+    "fonts-materialdesignicons-webfont": {
+      "source": "https://github.com/regolith-linux/fonts-materialdesignicons-webfont.git",
+      "ref": "r2_1"
+    },
+    "i3-wm": {
+      "source": "https://github.com/regolith-linux/i3-wm.git",
+      "ref": "r2_1"
+    },
+    "i3-gaps-wm": {
+      "source": "https://github.com/regolith-linux/i3-gaps-wm.git",
+      "ref": "r2_1"
+    },
+    "regolith-i3-config": {
+      "source": "https://github.com/regolith-linux/regolith-i3-config.git",
+      "ref": "r2_1"
+    },
+    "ayu-theme": {
+      "source": "https://github.com/regolith-linux/ayu-theme.git",
+      "ref": "r2_1"
+    },
+    "solarc-theme": {
+      "source": "https://github.com/regolith-linux/solarc-theme.git",
+      "ref": "r2_1"
+    },
+    "gruvbox-gtk": {
+      "source": "https://github.com/regolith-linux/gruvbox-gtk.git",
+      "ref": "r2_1"
+    },
+    "dracula-gtk": {
+      "source": "https://github.com/regolith-linux/dracula-gtk.git",
+      "ref": "r2_1"
+    },
+    "whitesur-gtk-theme": {
+      "source": "https://github.com/regolith-linux/whitesur-gtk-theme.git",
+      "ref": "r2_1"
+    },
+    "regolith-look-default": {
+      "source": "https://github.com/regolith-linux/regolith-look-default.git",
+      "ref": "r2_1"
+    },
+    "regolith-look-extra": {
+      "source": "https://github.com/regolith-linux/regolith-look-extra.git",
+      "ref": "r2_1"
+    },
+    "i3-next-workspace": {
+      "source": "https://github.com/regolith-linux/i3-next-workspace.git",
+      "ref": "r2_1"
+    },
+    "i3-swap-focus": {
+      "source": "https://github.com/regolith-linux/i3-swap-focus.git",
+      "ref": "r2_1"
+    },
+    "i3xrocks": {
+      "source": "https://github.com/regolith-linux/i3xrocks.git",
+      "ref": "r2_1"
+    },
+    "regolith-i3xrocks-config": {
+      "source": "https://github.com/regolith-linux/regolith-i3xrocks-config.git",
+      "ref": "r2_1"
+    },
+    "regolith-desktop": {
+      "source": "https://github.com/regolith-linux/regolith-desktop.git",
+      "ref": "r2_1"
+    },
+    "regolith-ftue": {
+      "source": "https://github.com/regolith-linux/regolith-ftue.git",
+      "ref": "r2_1"
+    },
+    "regolith-compositor-none": {
+      "source": "https://github.com/regolith-linux/regolith-compositor-none.git",
+      "ref": "r2_1"
+    },
+    "regolith-compositor-xcompmgr": {
+      "source": "https://github.com/regolith-linux/regolith-compositor-xcompmgr.git",
+      "ref": "r2_1"
+    },
+    "regolith-compositor-compton-glx": {
+      "source": "https://github.com/regolith-linux/regolith-compositor-compton-glx.git",
+      "ref": "r2_1"
+    },
+    "picom": {
+      "source": "https://github.com/regolith-linux/picom.git",
+      "ref": "r2_1"
+    },
+    "regolith-compositor-picom-glx": {
+      "source": "https://github.com/regolith-linux/regolith-compositor-picom-glx.git",
+      "ref": "r2_1"
+    },
+    "remontoire": {
+      "source": "https://github.com/regolith-linux/remontoire.git",
+      "ref": "r2_1"
+    },
+    "ilia": {
+      "source": "https://github.com/regolith-linux/ilia.git",
+      "ref": "r2_1"
+    },
+    "lago": {
+      "source": "https://github.com/regolith-linux/lago.git",
+      "ref": "r2_1"
+    },
+    "regolith-rofi-config": {
+      "source": "https://github.com/regolith-linux/regolith-rofi-config.git",
+      "ref": "r2_1"
+    },
+    "regolith-rofication": {
+      "source": "https://github.com/regolith-linux/regolith-rofication.git",
+      "ref": "r2_1"
+    },
+    "regolith-control-center": {
+      "source": "https://github.com/regolith-linux/regolith-control-center.git",
+      "ref": "r2_1"
+    },
+    "regolith-default-settings": {
+      "source": "https://github.com/regolith-linux/regolith-default-settings.git",
+      "ref": "r2_1"
+    },
+    "plymouth-theme-regolith": {
+      "source": "https://github.com/regolith-linux/plymouth-theme-regolith.git",
+      "ref": "r2_1"
+    },
+    "regolith-distro-ubuntu": {
+      "source": "https://github.com/regolith-linux/regolith-distro-ubuntu.git",
+      "ref": "r2_1"
+    },
+    "xrescat": {
+      "source": "https://github.com/regolith-linux/xrescat.git",
+      "ref": "r2_1"
+    },
+    "regolith-unclutter-xfixes": {
+      "source": "https://github.com/regolith-linux/regolith-unclutter-xfixes.git",
+      "ref": "r2_1"
+    },
+    "arc-icon-theme": {
+      "source": "https://github.com/regolith-linux/arc-icon-theme.git",
+      "ref": "r2_1"
+    },
+    "nordic": {
+      "source": "https://github.com/regolith-linux/nordic.git",
+      "ref": "r2_1"
+    },
+    "fonts-source-code-pro-ttf": {
+      "source": "https://github.com/regolith-linux/fonts-source-code-pro-ttf.git",
+      "ref": "r2_1"
+    },
+    "fonts-nerd-fonts": {
+      "source": "https://github.com/regolith-linux/fonts-nerd-fonts.git",
+      "ref": "r2_1"
+    }
+  }
+}

--- a/stage/release-2_1/ubuntu/jammy/package-model.json
+++ b/stage/release-2_1/ubuntu/jammy/package-model.json
@@ -1,0 +1,21 @@
+{
+  "packages": {
+    "ilia": {
+      "source": "https://github.com/regolith-linux/ilia.git",
+      "ref": "r2_1-ubuntu-jammy"
+    },
+    "lago": {
+      "source": "https://github.com/regolith-linux/lago.git",
+      "ref": "r2_1-ubuntu-jammy"
+    },
+    "regolith-control-center": {
+      "source": "https://github.com/regolith-linux/regolith-control-center.git",
+      "ref": "r2_1-ubuntu-jammy"
+
+    },
+    "ubiquity-slideshow-regolith": {
+      "source": "https://github.com/regolith-linux/ubiquity-slideshow-regolith.git",
+      "ref": "r2_1-ubuntu-jammy"
+    }
+  }
+}


### PR DESCRIPTION
Related to https://github.com/orgs/regolith-linux/discussions/792

This change copies the `release` stage from the 2.1 release into a `release-2_1` stage.  I've never tried rebuilding an older version so there maybe some unknown reason why this doesn't work.

I'd planned to copy the deb repo dirs from the server before running the 2.2 release but forgot so they were overwritten.  Had I done that this wouldn't be necessary.  In any case, a good way to test the robustness of the build system!