### PR TITLE
Disable regolith-aviso on focal due to older dependency requirements

### DIFF
--- a/stage/experimental/ubuntu/focal/package-model.json
+++ b/stage/experimental/ubuntu/focal/package-model.json
@@ -1,5 +1,6 @@
 {
   "packages": {
-    "ilia": null
+    "ilia": null,
+    "regolith-avizo": null
   }
 }


### PR DESCRIPTION

See https://github.com/regolith-linux/voulage/actions/runs/3783013435/jobs/6431219813 for build failure.