### PR TITLE
publish to launchpad

### DIFF
--- a/.github/scripts/ext-debian.sh
+++ b/.github/scripts/ext-debian.sh
@@ -129,6 +129,14 @@ publish() {
           fi
       done
   done
+
+  # Preliminary launchpad.net integration. Ideally gated from action rather than distro/stage
+  if [[ "$DISTRO" == "ubuntu" && "$STAGE" == "unstable" ]]; then
+    echo "Publishing $DEB_SRC_PKG_PATH to launchpad.net"
+    LAUNCHPAD_REPO="ppa:regolith-desktop/$STAGE"
+
+    dput $LAUNCHPAD_REPO $DEB_SRC_PKG_PATH
+  fi
 }
 
 # Create repo dist file

--- a/.github/workflows/build-deb-v4.yml
+++ b/.github/workflows/build-deb-v4.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
-        stage: [experimental, unstable, testing, release, release-2_1]
+        stage: [experimental, unstable, testing, release] #, release-2_1]
         distro-codename: [ubuntu-focal-amd64, ubuntu-focal-arm64, ubuntu-jammy-amd64, ubuntu-jammy-arm64, ubuntu-kinetic-amd64, ubuntu-kinetic-arm64, debian-bullseye-amd64, debian-bullseye-arm64, debian-testing-amd64]
         exclude:
           - stage: release
@@ -107,7 +107,7 @@ jobs:
           # fi
 
           set -e
-          DEBIAN_FRONTEND=noninteractive sudo apt install -y --no-install-recommends jq git devscripts reprepro wget
+          DEBIAN_FRONTEND=noninteractive sudo apt install -y --no-install-recommends jq git devscripts reprepro wget dput
       - name: Pull Manifest
         run: |
           set -e


### PR DESCRIPTION
Testing support for publishing ubuntu source packages from unstable stage to launchpad.net.

This change will be tested after merging.