### PR TITLE
Update changelog entry generation to be unique per codename

### DIFF
--- a/.github/scripts/ext-debian.sh
+++ b/.github/scripts/ext-debian.sh
@@ -135,7 +135,7 @@ publish() {
     echo "Publishing $DEB_SRC_PKG_PATH to launchpad.net"
     LAUNCHPAD_REPO="ppa:regolith-desktop/$STAGE"
 
-    dput $LAUNCHPAD_REPO $DEB_SRC_PKG_PATH
+    dput -f $LAUNCHPAD_REPO $DEB_SRC_PKG_PATH
   fi
 }
 

--- a/.github/scripts/ext-debian.sh
+++ b/.github/scripts/ext-debian.sh
@@ -11,7 +11,7 @@ update_changelog() {
   set -x
   cd "${PKG_BUILD_DIR:?}/$PACKAGE_NAME"
   version=$(dpkg-parsechangelog --show-field Version)
-  dch --distribution "$CODENAME" --newversion "${version}-1regolith" "Automated release."
+  dch --distribution "$CODENAME" --newversion "${version}-1regolith-$CODENAME" "Automated Voulage release"
 
   cd - >/dev/null 2>&1 || exit
 }


### PR DESCRIPTION
Change is an attempt (untested) to resolve issues like:

```
Rejected:
File regolith-look-default_0.7.5.orig.tar.gz already exists in unstable, but uploaded version has different contents. See more information about this error in https://help.launchpad.net/Packaging/UploadErrors.
File regolith-look-default_0.7.5-1regolith.debian.tar.xz already exists in unstable, but uploaded version has different contents. See more information about this error in https://help.launchpad.net/Packaging/UploadErrors.
Files specified in DSC are broken or missing, skipping package unpack verification.
```
