### PR TITLE
seperate packages per codename for launchpad

### DIFF
--- a/.github/scripts/ext-debian.sh
+++ b/.github/scripts/ext-debian.sh
@@ -135,7 +135,7 @@ publish() {
   # Arch is set to amd64 because launchpad handles cross arch builds internally
   # Remove STAGE check once testing and release PPAs are ready
   if [[ "$DISTRO" == "ubuntu" && "$ARCH" == "amd64" && "$STAGE" == "unstable" ]]; then    
-    LAUNCHPAD_REPO="ppa:regolith-desktop/$STAGE"
+    LAUNCHPAD_REPO="ppa:regolith-desktop/$CODENAME-$STAGE"
 
     dput -f $LAUNCHPAD_REPO $DEB_SRC_PKG_PATH
 


### PR DESCRIPTION

Launchpad.net (maybe upstream constraint, unsure) requires that for a given PPA, that a source package is globally unique.  However for regolith packages this is the exception: most packages work without changes across releases.  This change includes an external change in launchpad that creates a PPA per release.  This (hopefully) will sidestep the source publishing constraint at the cost of a more complex PPA setup.  (from one per stage to n per stage where n is the total number of supported Ubuntu releases)