### PR TITLE
Various fixes for bullseye

### DIFF
--- a/stage/experimental/debian/bullseye/amd64/setup.sh
+++ b/stage/experimental/debian/bullseye/amd64/setup.sh
@@ -2,4 +2,6 @@
 
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily
 sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/experimental/debian/bullseye/amd64/setup.sh
+++ b/stage/experimental/debian/bullseye/amd64/setup.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# This PPA adds nececessary backports for debbuild helper 13
-sudo apt install -y software-properties-common
-
-sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/experimental/debian/bullseye/amd64/setup.sh
+++ b/stage/experimental/debian/bullseye/amd64/setup.sh
@@ -3,5 +3,4 @@
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
 
-sudo add-apt-repository --remove -y ppa:videolan/master-daily
-sudo add-apt-repository -y ppa:videolan/master-daily
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/experimental/debian/bullseye/amd64/setup.sh
+++ b/stage/experimental/debian/bullseye/amd64/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This PPA adds nececessary backports for debbuild helper 13
+sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/release-2_1/debian/bullseye/amd64/setup.sh
+++ b/stage/release-2_1/debian/bullseye/amd64/setup.sh
@@ -2,4 +2,6 @@
 
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily
 sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/release-2_1/debian/bullseye/amd64/setup.sh
+++ b/stage/release-2_1/debian/bullseye/amd64/setup.sh
@@ -3,5 +3,4 @@
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
 
-sudo add-apt-repository --remove -y ppa:videolan/master-daily
-sudo add-apt-repository -y ppa:videolan/master-daily
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/release-2_2/debian/bullseye/amd64/setup.sh
+++ b/stage/release-2_2/debian/bullseye/amd64/setup.sh
@@ -2,4 +2,6 @@
 
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily
 sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/release-2_2/debian/bullseye/amd64/setup.sh
+++ b/stage/release-2_2/debian/bullseye/amd64/setup.sh
@@ -3,5 +3,4 @@
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
 
-sudo add-apt-repository --remove -y ppa:videolan/master-daily
-sudo add-apt-repository -y ppa:videolan/master-daily
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/release-3_0/debian/bullseye/amd64/setup.sh
+++ b/stage/release-3_0/debian/bullseye/amd64/setup.sh
@@ -2,4 +2,6 @@
 
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily
 sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/release-3_0/debian/bullseye/amd64/setup.sh
+++ b/stage/release-3_0/debian/bullseye/amd64/setup.sh
@@ -3,5 +3,4 @@
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
 
-sudo add-apt-repository --remove -y ppa:videolan/master-daily
-sudo add-apt-repository -y ppa:videolan/master-daily
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/testing/debian/bullseye/amd64/setup.sh
+++ b/stage/testing/debian/bullseye/amd64/setup.sh
@@ -2,4 +2,6 @@
 
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily
 sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/testing/debian/bullseye/amd64/setup.sh
+++ b/stage/testing/debian/bullseye/amd64/setup.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# This PPA adds nececessary backports for debbuild helper 13
-sudo apt install -y software-properties-common
-
-sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/testing/debian/bullseye/amd64/setup.sh
+++ b/stage/testing/debian/bullseye/amd64/setup.sh
@@ -3,5 +3,4 @@
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
 
-sudo add-apt-repository --remove -y ppa:videolan/master-daily
-sudo add-apt-repository -y ppa:videolan/master-daily
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/testing/debian/bullseye/amd64/setup.sh
+++ b/stage/testing/debian/bullseye/amd64/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This PPA adds nececessary backports for debbuild helper 13
+sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/testing/debian/bullseye/package-model.json
+++ b/stage/testing/debian/bullseye/package-model.json
@@ -10,7 +10,7 @@
     },
     "regolith-control-center": {
       "source": "https://github.com/regolith-linux/regolith-control-center.git",
-      "ref": "ubuntu/jammy"
+      "ref": "r3_1-beta1-debian-bullseye"
     },
     "i3status-rs": null,
     "regolith-displayd": null,

--- a/stage/testing/debian/bullseye/package-model.json
+++ b/stage/testing/debian/bullseye/package-model.json
@@ -8,6 +8,10 @@
       "source": "https://git.launchpad.net/ubuntu/+source/xcb-util",
       "ref": "applied/ubuntu/groovy"
     },
+    "regolith-control-center": {
+      "source": "https://github.com/regolith-linux/regolith-control-center.git",
+      "ref": "ubuntu/jammy"
+    },
     "i3status-rs": null,
     "regolith-displayd": null,
     "regolith-inputd": null,

--- a/stage/unstable/debian/bullseye/amd64/setup.sh
+++ b/stage/unstable/debian/bullseye/amd64/setup.sh
@@ -2,4 +2,6 @@
 
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily
 sudo add-apt-repository -y ppa:videolan/master-daily

--- a/stage/unstable/debian/bullseye/amd64/setup.sh
+++ b/stage/unstable/debian/bullseye/amd64/setup.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# This PPA adds nececessary backports for debbuild helper 13
-sudo apt install -y software-properties-common
-
-sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/unstable/debian/bullseye/amd64/setup.sh
+++ b/stage/unstable/debian/bullseye/amd64/setup.sh
@@ -3,5 +3,4 @@
 # This PPA adds nececessary backports for debbuild helper 13
 sudo apt install -y software-properties-common
 
-sudo add-apt-repository --remove -y ppa:videolan/master-daily
-sudo add-apt-repository -y ppa:videolan/master-daily
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/unstable/debian/bullseye/amd64/setup.sh
+++ b/stage/unstable/debian/bullseye/amd64/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This PPA adds nececessary backports for debbuild helper 13
+sudo apt install -y software-properties-common
+
+sudo add-apt-repository --remove -y ppa:videolan/master-daily || true

--- a/stage/unstable/debian/bullseye/package-model.json
+++ b/stage/unstable/debian/bullseye/package-model.json
@@ -8,6 +8,10 @@
       "source": "https://git.launchpad.net/ubuntu/+source/xcb-util",
       "ref": "applied/ubuntu/groovy"
     },
+    "regolith-control-center": {
+      "source": "https://github.com/regolith-linux/regolith-control-center.git",
+      "ref": "debian-bullseye"
+    },
     "i3status-rs": null,
     "regolith-displayd": null,
     "regolith-inputd": null,


### PR DESCRIPTION
Before we were using github managed servers for bullseye builds.  Something changed in them causing previously working builds to fail.  Decided to move to Regolith-managed hosts for more control.