### PR TITLE
fix: enable xdg-desktop-portal-regolith to build on jammy

### DIFF
--- a/stage/unstable/ubuntu/jammy/package-model.json
+++ b/stage/unstable/ubuntu/jammy/package-model.json
@@ -17,7 +17,6 @@
     "sway-regolith": {
       "ref": "packaging/v1.7-regolith",
       "source": "https://github.com/regolith-linux/sway-regolith.git"
-    },
-    "xdg-desktop-portal-regolith": null
+    }
   }
 }


### PR DESCRIPTION
address https://github.com/regolith-linux/regolith-desktop/issues/920