### PR TITLE
feat: use master branch for regolith-rofi-config

### DIFF
--- a/.github/scripts/tag-stage.sh
+++ b/.github/scripts/tag-stage.sh
@@ -107,8 +107,6 @@ handle_package() {
     tag_package "$DEFAULT_DEST_TAG"
   elif [[ "$PACKAGE_SOURCE_REF" == "ubuntu/v0.22.0" && "$PACKAGE_NAME" == "i3status-rs" ]]; then
     tag_package "$DEFAULT_DEST_TAG-ubuntu-jammy"
-  elif [[ "$PACKAGE_SOURCE_REF" == "i3cp" && "$PACKAGE_NAME" == "regolith-rofi-config" ]]; then
-    tag_package "$DEFAULT_DEST_TAG"
   elif [[ "$PACKAGE_SOURCE_REF" == "packaging/v1.7-regolith" && "$PACKAGE_NAME" == "sway-regolith" ]]; then
     tag_package "$DEFAULT_DEST_TAG-ubuntu-jammy"
   elif [[ "$PACKAGE_SOURCE_REF" == "packaging/v1.8-regolith" && "$PACKAGE_NAME" == "sway-regolith" ]]; then

--- a/stage/unstable/package-model.json
+++ b/stage/unstable/package-model.json
@@ -161,7 +161,7 @@
       "source": "https://github.com/regolith-linux/regolith-powerd.git"
     },
     "regolith-rofi-config": {
-      "ref": "i3cp",
+      "ref": "master",
       "source": "https://github.com/regolith-linux/regolith-rofi-config.git"
     },
     "regolith-rofication": {


### PR DESCRIPTION
As per https://github.com/regolith-linux/regolith-rofi-config/pull/5 we are going to use master branch from now on.

Corresponding section in tag-stage.sh has been updated to reflect this change as well.