### PR TITLE
fix: build regolith-session on different branches due to package removal in debian testing

### DIFF
--- a/stage/testing/debian/bookworm/package-model.json
+++ b/stage/testing/debian/bookworm/package-model.json
@@ -14,6 +14,10 @@
     "regolith-displayd": null,
     "regolith-inputd": null,
     "regolith-powerd": null,
+    "regolith-session": {
+      "ref": "r3_3-beta1-debian-bookworm",
+      "source": "https://github.com/regolith-linux/xdg-desktop-portal-regolith.git"
+    },
     "regolith-sway-touchpad-gestures": null,
     "sway-audio-idle-inhibit": null,
     "sway-regolith": null,

--- a/stage/testing/ubuntu/jammy/package-model.json
+++ b/stage/testing/ubuntu/jammy/package-model.json
@@ -13,6 +13,10 @@
       "ref": "r3_3-beta1-ubuntu-jammy",
       "source": "https://github.com/regolith-linux/regolith-control-center.git"
     },
+    "regolith-session": {
+      "ref": "r3_3-beta1-debian-bookworm",
+      "source": "https://github.com/regolith-linux/xdg-desktop-portal-regolith.git"
+    },
     "regolith-sway-touchpad-gestures": null,
     "sway-regolith": {
       "ref": "r3_3-beta1-ubuntu-jammy",

--- a/stage/unstable/debian/bookworm/package-model.json
+++ b/stage/unstable/debian/bookworm/package-model.json
@@ -14,6 +14,10 @@
     "regolith-displayd": null,
     "regolith-inputd": null,
     "regolith-powerd": null,
+    "regolith-session": {
+      "ref": "debian-bookworm",
+      "source": "https://github.com/regolith-linux/xdg-desktop-portal-regolith.git"
+    },
     "regolith-sway-touchpad-gestures": null,
     "sway-audio-idle-inhibit": null,
     "sway-regolith": null,

--- a/stage/unstable/ubuntu/jammy/package-model.json
+++ b/stage/unstable/ubuntu/jammy/package-model.json
@@ -13,6 +13,10 @@
       "ref": "ubuntu/jammy",
       "source": "https://github.com/regolith-linux/regolith-control-center.git"
     },
+    "regolith-session": {
+      "ref": "debian-bookworm",
+      "source": "https://github.com/regolith-linux/xdg-desktop-portal-regolith.git"
+    },
     "regolith-sway-touchpad-gestures": null,
     "sway-regolith": {
       "ref": "packaging/v1.7-regolith",


### PR DESCRIPTION


A dependency in regolith-session-flashback has been removed from the [Debian repos](https://packages.debian.org/bookworm/policykit-1-gnome).  This causes [failure at install time](https://github.com/regolith-linux/voulage/actions/runs/12979166882/job/36194602436) as `apt` cannot find the dependency.  Ubuntu [doesn't seem to have removed this package](https://launchpad.net/ubuntu/+source/policykit-1-gnome), so it doesn't seem like it matters either way there.  In this PR I set older distros to use the older package version that expresses the dependency.  Because the new behavior is on the `main` branch, newer distro/codenames will take the new package by default.