### PR TITLE
chore: build regolith-avizo from master

### DIFF
--- a/stage/unstable/package-model.json
+++ b/stage/unstable/package-model.json
@@ -93,7 +93,7 @@
       "source": "https://github.com/regolith-linux/python3-i3ipc"
     },
     "regolith-avizo": {
-      "ref": "ubuntu/jammy",
+      "ref": "master",
       "source": "https://github.com/regolith-linux/avizo.git"
     },
     "regolith-compositor-compton-glx": {


### PR DESCRIPTION
It looks to be safe to build `regolith-avizo` for all the distros off top of `master`.