### PR TITLE
chore: modify primary ref for couple of packages

### DIFF
--- a/stage/testing/debian/testing/package-model.json
+++ b/stage/testing/debian/testing/package-model.json
@@ -1,5 +1,9 @@
 {
   "packages": {
+    "i3status-rs": {
+      "ref": "v0.22.1-1-ubuntu-jammy",
+      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
+    },
     "plymouth-theme-regolith": null,
     "ubiquity-slideshow-regolith": null
   }

--- a/stage/testing/debian/testing/package-model.json
+++ b/stage/testing/debian/testing/package-model.json
@@ -1,10 +1,6 @@
 {
   "packages": {
     "plymouth-theme-regolith": null,
-    "regolith-control-center": {
-      "ref": "v1.46.0-3-gnome-46",
-      "source": "https://github.com/regolith-linux/regolith-control-center.git"
-    },
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/testing/package-model.json
+++ b/stage/testing/package-model.json
@@ -113,7 +113,7 @@
       "source": "https://github.com/regolith-linux/regolith-compositor-xcompmgr.git"
     },
     "regolith-control-center": {
-      "ref": "r3_3-beta1",
+      "ref": "v1.46.0-3-gnome-46",
       "source": "https://github.com/regolith-linux/regolith-control-center.git"
     },
     "regolith-default-settings": {

--- a/stage/testing/package-model.json
+++ b/stage/testing/package-model.json
@@ -57,7 +57,7 @@
       "source": "https://github.com/regolith-linux/i3-swap-focus.git"
     },
     "i3status-rs": {
-      "ref": "v0.22.1-1-ubuntu-jammy",
+      "ref": "v0.32.1",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
     "i3xrocks": {

--- a/stage/testing/ubuntu/jammy/package-model.json
+++ b/stage/testing/ubuntu/jammy/package-model.json
@@ -5,6 +5,10 @@
       "ref": "v4.22-1",
       "source": "https://github.com/regolith-linux/i3-wm.git"
     },
+    "i3status-rs": {
+      "ref": "v0.22.1-1-ubuntu-jammy",
+      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
+    },
     "regolith-control-center": {
       "ref": "v1.41.18-ubuntu-jammy",
       "source": "https://github.com/regolith-linux/regolith-control-center.git"

--- a/stage/testing/ubuntu/noble/package-model.json
+++ b/stage/testing/ubuntu/noble/package-model.json
@@ -1,9 +1,5 @@
 {
   "packages": {
-    "i3status-rs": {
-      "ref": "v0.32.1",
-      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
-    },
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/testing/ubuntu/noble/package-model.json
+++ b/stage/testing/ubuntu/noble/package-model.json
@@ -4,10 +4,6 @@
       "ref": "v0.32.1",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
-    "regolith-control-center": {
-      "ref": "v1.46.0-3-gnome-46",
-      "source": "https://github.com/regolith-linux/regolith-control-center.git"
-    },
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/testing/ubuntu/oracular/package-model.json
+++ b/stage/testing/ubuntu/oracular/package-model.json
@@ -1,9 +1,5 @@
 {
   "packages": {
-    "i3status-rs": {
-      "ref": "v0.32.1",
-      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
-    },
     "regolith-control-center": null,
     "ubiquity-slideshow-regolith": null
   }

--- a/stage/unstable/debian/testing/package-model.json
+++ b/stage/unstable/debian/testing/package-model.json
@@ -1,5 +1,9 @@
 {
   "packages": {
+    "i3status-rs": {
+      "ref": "ubuntu/v0.22.0",
+      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
+    },
     "plymouth-theme-regolith": null,
     "ubiquity-slideshow-regolith": null
   }

--- a/stage/unstable/debian/testing/package-model.json
+++ b/stage/unstable/debian/testing/package-model.json
@@ -1,10 +1,6 @@
 {
   "packages": {
     "plymouth-theme-regolith": null,
-    "regolith-control-center": {
-      "ref": "regolith/46",
-      "source": "https://github.com/regolith-linux/regolith-control-center.git"
-    },
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/unstable/package-model.json
+++ b/stage/unstable/package-model.json
@@ -57,7 +57,7 @@
       "source": "https://github.com/regolith-linux/i3-swap-focus.git"
     },
     "i3status-rs": {
-      "ref": "ubuntu/v0.22.0",
+      "ref": "ubuntu/v0.32.1",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
     "i3xrocks": {

--- a/stage/unstable/package-model.json
+++ b/stage/unstable/package-model.json
@@ -113,7 +113,7 @@
       "source": "https://github.com/regolith-linux/regolith-compositor-xcompmgr.git"
     },
     "regolith-control-center": {
-      "ref": "main",
+      "ref": "regolith/46",
       "source": "https://github.com/regolith-linux/regolith-control-center.git"
     },
     "regolith-default-settings": {

--- a/stage/unstable/ubuntu/jammy/package-model.json
+++ b/stage/unstable/ubuntu/jammy/package-model.json
@@ -5,6 +5,10 @@
       "ref": "main",
       "source": "https://github.com/regolith-linux/i3-wm.git"
     },
+    "i3status-rs": {
+      "ref": "ubuntu/v0.22.0",
+      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
+    },
     "regolith-control-center": {
       "ref": "ubuntu/jammy",
       "source": "https://github.com/regolith-linux/regolith-control-center.git"

--- a/stage/unstable/ubuntu/noble/package-model.json
+++ b/stage/unstable/ubuntu/noble/package-model.json
@@ -1,9 +1,5 @@
 {
   "packages": {
-    "i3status-rs": {
-      "ref": "ubuntu/v0.32.1",
-      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
-    },
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/unstable/ubuntu/noble/package-model.json
+++ b/stage/unstable/ubuntu/noble/package-model.json
@@ -4,10 +4,6 @@
       "ref": "ubuntu/v0.32.1",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
-    "regolith-control-center": {
-      "ref": "regolith/46",
-      "source": "https://github.com/regolith-linux/regolith-control-center.git"
-    },
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/unstable/ubuntu/oracular/package-model.json
+++ b/stage/unstable/ubuntu/oracular/package-model.json
@@ -1,9 +1,5 @@
 {
   "packages": {
-    "i3status-rs": {
-      "ref": "ubuntu/v0.32.1",
-      "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
-    },
     "regolith-control-center": null,
     "ubiquity-slideshow-regolith": null
   }


### PR DESCRIPTION
Use the following primary ref for the provided packages:

- `i3status-rs`: use `ubuntu/v0.32.1` as primary ref and adjust the necessary distro overrides
- `regolith-control-center`: use `regolith/46` as primary ref and adjust the necessary distro overrides

This PR also adjusts the corresponding released tags of the above packages in the corresponding `stage/testing/` model files.