### PR TITLE
chore: some fix and cleanup on package models

### DIFF
--- a/stage/testing/ubuntu/jammy/package-model.json
+++ b/stage/testing/ubuntu/jammy/package-model.json
@@ -21,7 +21,6 @@
     "sway-regolith": {
       "ref": "v1.7-7-ubuntu-jammy",
       "source": "https://github.com/regolith-linux/sway-regolith.git"
-    },
-    "xdg-desktop-portal-regolith": null
+    }
   }
 }

--- a/stage/unstable/package-model.json
+++ b/stage/unstable/package-model.json
@@ -90,7 +90,7 @@
     },
     "python3-i3ipc": {
       "ref": "master",
-      "source": "https://github.com/regolith-linux/python3-i3ipc"
+      "source": "https://github.com/regolith-linux/python3-i3ipc.git"
     },
     "regolith-avizo": {
       "ref": "master",
@@ -214,7 +214,7 @@
     },
     "whitesur-gtk-theme": {
       "ref": "debian",
-      "source": "https://github.com/regolith-linux/whitesur-gtk-theme.git"
+      "source": "https://github.com/regolith-linux/WhiteSur-gtk-theme.git"
     },
     "xdg-desktop-portal-regolith": {
       "ref": "main",


### PR DESCRIPTION
- make sure package source name is consistent everywhere:
  - `regolith-linux/WhiteSur-gtk-theme` must be camel case to be case sensitive
  - `regolith-linux/python3-i3ipc` must end with `.git`
- enable `xdg-desktop-portal-regolith` for `jammy` on `testing`