### PR TITLE
chore: temporary disable sway-reglith on debian testing

### DIFF
--- a/stage/testing/debian/testing/package-model.json
+++ b/stage/testing/debian/testing/package-model.json
@@ -5,6 +5,7 @@
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
     "plymouth-theme-regolith": null,
+    "sway-regolith": null,
     "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/unstable/debian/testing/package-model.json
+++ b/stage/unstable/debian/testing/package-model.json
@@ -9,6 +9,7 @@
       "ref": "fix/trixie-session-init-1094494",
       "source": "https://github.com/regolith-linux/regolith-session.git"
     },
+    "sway-regolith": null,
     "ubiquity-slideshow-regolith": null
   }
 }


### PR DESCRIPTION
libwlroot-dev was removed from Debian Trixie repos altogether and as such sway-regolith cannot be built. We will start using v1.10 for it. In the meantime disabling this to get the CI green.