### PR TITLE
feat: enable ubiquity-slideshow for all Ubuntu releases

### DIFF
--- a/stage/testing/ubuntu/noble/package-model.json
+++ b/stage/testing/ubuntu/noble/package-model.json
@@ -1,5 +1,4 @@
 {
   "packages": {
-    "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/testing/ubuntu/oracular/package-model.json
+++ b/stage/testing/ubuntu/oracular/package-model.json
@@ -1,6 +1,5 @@
 {
   "packages": {
-    "regolith-control-center": null,
-    "ubiquity-slideshow-regolith": null
+    "regolith-control-center": null
   }
 }

--- a/stage/unstable/ubuntu/noble/package-model.json
+++ b/stage/unstable/ubuntu/noble/package-model.json
@@ -1,5 +1,4 @@
 {
   "packages": {
-    "ubiquity-slideshow-regolith": null
   }
 }

--- a/stage/unstable/ubuntu/oracular/package-model.json
+++ b/stage/unstable/ubuntu/oracular/package-model.json
@@ -1,6 +1,5 @@
 {
   "packages": {
-    "regolith-control-center": null,
-    "ubiquity-slideshow-regolith": null
+    "regolith-control-center": null
   }
 }


### PR DESCRIPTION
Enable `ubiquity-slideshow-regolith` package for all the ~distros~ Ubuntu releases.

**Update:** Ubiquity only will be used in the ISOs where base distro is Ubuntu.

/ref: https://github.com/regolith-linux/ubiquity-slideshow-regolith/pull/3