### PR TITLE
chore: enable plymouth-theme for all distro

### DIFF
--- a/stage/testing/debian/bookworm/package-model.json
+++ b/stage/testing/debian/bookworm/package-model.json
@@ -5,7 +5,6 @@
     "gtklock": null,
     "i3status-rs": null,
     "libtrawldb": null,
-    "plymouth-theme-regolith": null,
     "regolith-avizo": null,
     "regolith-control-center": {
       "ref": "v1.43.1-8-gnome-43",

--- a/stage/testing/debian/testing/package-model.json
+++ b/stage/testing/debian/testing/package-model.json
@@ -4,7 +4,6 @@
       "ref": "v0.22.2-1-ubuntu-jammy",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
-    "plymouth-theme-regolith": null,
     "sway-regolith": null,
     "ubiquity-slideshow-regolith": null
   }

--- a/stage/unstable/debian/bookworm/package-model.json
+++ b/stage/unstable/debian/bookworm/package-model.json
@@ -5,7 +5,6 @@
     "gtklock": null,
     "i3status-rs": null,
     "libtrawldb": null,
-    "plymouth-theme-regolith": null,
     "regolith-avizo": null,
     "regolith-control-center": {
       "ref": "regolith/1%43.0-1",

--- a/stage/unstable/debian/testing/package-model.json
+++ b/stage/unstable/debian/testing/package-model.json
@@ -4,7 +4,6 @@
       "ref": "ubuntu/v0.22.0",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
-    "plymouth-theme-regolith": null,
     "regolith-session": {
       "ref": "fix/trixie-session-init-1094494",
       "source": "https://github.com/regolith-linux/regolith-session.git"


### PR DESCRIPTION
Enabling `plymouth-theme-regolith` for all distros, specifically for debian.