### PR TITLE
chore: add xdg-desktop-portal-regolith to jammy testing

### DIFF
--- a/stage/testing/ubuntu/jammy/package-model.json
+++ b/stage/testing/ubuntu/jammy/package-model.json
@@ -21,6 +21,10 @@
     "sway-regolith": {
       "ref": "v1.7-8-ubuntu-jammy",
       "source": "https://github.com/regolith-linux/sway-regolith.git"
+    },
+    "xdg-desktop-portal-regolith": {
+      "ref": "TBA",
+      "source": "https://github.com/regolith-linux/xdg-desktop-portal-regolith.git"
     }
   }
 }


### PR DESCRIPTION
Note: the version is set to `TBA` which will be generated and replaced properly after running update changelog version action.