### PR TITLE
feat: add regolith-control-center ported from gnome 48

### DIFF
--- a/stage/unstable/ubuntu/plucky/package-model.json
+++ b/stage/unstable/ubuntu/plucky/package-model.json
@@ -1,6 +1,9 @@
 {
   "packages": {
-    "regolith-control-center": null,
+    "regolith-control-center": {
+      "ref": "regolith/48",
+      "source": "https://github.com/regolith-linux/regolith-control-center.git"
+    },
     "sway-regolith": {
       "ref": "packaging/v1.10-regolith",
       "source": "https://github.com/regolith-linux/sway-regolith.git"


### PR DESCRIPTION
* tested basics
* tested can update wallpaper
* didn't see any errors on console when launching