### PR TITLE
feat: promote regolith-control-center to plucky testing

### DIFF
--- a/stage/testing/ubuntu/plucky/package-model.json
+++ b/stage/testing/ubuntu/plucky/package-model.json
@@ -1,6 +1,9 @@
 {
   "packages": {
-    "regolith-control-center": null,
+    "regolith-control-center": {
+      "ref": "TBA",
+      "source": "https://github.com/regolith-linux/regolith-control-center.git"
+    },
     "sway-regolith": {
       "ref": "v1.10-2",
       "source": "https://github.com/regolith-linux/sway-regolith.git"


### PR DESCRIPTION
ref is set to `TBA` which will be updated by the corresponding downstream action.