### PR TITLE
fix: don't run tests after build

### DIFF
--- a/.github/workflows/build-deb-v5.yml
+++ b/.github/workflows/build-deb-v5.yml
@@ -511,14 +511,3 @@ jobs:
           commit_user_name: regolith-ci-bot
           commit_user_email: bot@regolith-desktop.com
           commit_author: "regolith-ci-bot <bot@regolith-desktop.com>"
-
-  # run the tests
-  test:
-    needs: [manifests]
-    if: ${{ !failure() && !cancelled() && inputs.do-publish == 'yes' }}
-    uses: ./.github/workflows/test-desktop-installable2.yml
-    with:
-      stage: ${{ inputs.stage }}
-      distro: ${{ inputs.distro }}
-      codename: ${{ inputs.codename }}
-      arch: ${{ inputs.arch }}


### PR DESCRIPTION
Historically we used to run test matrix right after packages were built and published. But most of the time the tests would fail (because we might have built only one package), or there are some skipped distros in the test matrix which would show up as failed.