### PR TITLE
fix: update package model for debian testing and trixie for gnome 48

### DIFF
--- a/stage/unstable/debian/testing/package-model.json
+++ b/stage/unstable/debian/testing/package-model.json
@@ -4,6 +4,10 @@
       "ref": "ubuntu/v0.22.0",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
+    "regolith-control-center": {
+      "ref": "regolith/48",
+      "source": "https://github.com/regolith-linux/regolith-control-center.git"
+    },
     "regolith-session": {
       "ref": "fix/trixie-session-init-1094494",
       "source": "https://github.com/regolith-linux/regolith-session.git"

--- a/stage/unstable/debian/trixie/package-model.json
+++ b/stage/unstable/debian/trixie/package-model.json
@@ -4,6 +4,10 @@
       "ref": "ubuntu/v0.22.0",
       "source": "https://github.com/regolith-linux/i3status-rs_debian.git"
     },
+    "regolith-control-center": {
+      "ref": "regolith/48",
+      "source": "https://github.com/regolith-linux/regolith-control-center.git"
+    },
     "regolith-session": {
       "ref": "fix/trixie-session-init-1094494",
       "source": "https://github.com/regolith-linux/regolith-session.git"


### PR DESCRIPTION
Trixie ships with GNOME 48.  The package model is [configured for GNOME 46](https://github.com/regolith-linux/voulage/blob/main/stage/unstable/package-model.json#L120).  Related to https://github.com/regolith-linux/regolith-desktop/issues/1139.

https://www.debian.org/News/2025/20250809

