### PR TITLE
chore: remove support for end-of-life oracular

### DIFF
--- a/.github/workflows/test-desktop-installable2.yml
+++ b/.github/workflows/test-desktop-installable2.yml
@@ -474,7 +474,7 @@ jobs:
     runs-on: ${{ fromJSON(needs.matrix-builder.outputs.runners)[matrix.arch] }}
     needs: matrix-builder
     if: |
-      (inputs.legacy == 'no') &&
+      (inputs.legacy == 'yes') &&
       (
         (inputs.distro == '' && inputs.codename == '') ||
         (inputs.distro == 'ubuntu' && inputs.codename == '') ||

--- a/stage/testing/ubuntu/oracular/package-model.json
+++ b/stage/testing/ubuntu/oracular/package-model.json
@@ -1,5 +1,0 @@
-{
-  "packages": {
-    "regolith-control-center": null
-  }
-}

--- a/stage/unstable/ubuntu/oracular/package-model.json
+++ b/stage/unstable/ubuntu/oracular/package-model.json
@@ -1,5 +1,0 @@
-{
-  "packages": {
-    "regolith-control-center": null
-  }
-}


### PR DESCRIPTION
Oracular reached EOL in July 2025.