### PR TITLE
chore: upgrade resolute and testing to sway v1.11

### DIFF
--- a/stage/unstable/debian/testing/package-model.json
+++ b/stage/unstable/debian/testing/package-model.json
@@ -9,7 +9,7 @@
       "source": "https://github.com/regolith-linux/regolith-control-center.git"
     },
     "sway-regolith": {
-      "ref": "packaging/v1.10-regolith",
+      "ref": "packaging/v1.11-regolith",
       "source": "https://github.com/regolith-linux/sway-regolith.git"
     },
     "ubiquity-slideshow-regolith": null

--- a/stage/unstable/ubuntu/resolute/package-model.json
+++ b/stage/unstable/ubuntu/resolute/package-model.json
@@ -5,7 +5,7 @@
       "source": "https://github.com/regolith-linux/regolith-control-center.git"
     },
     "sway-regolith": {
-      "ref": "packaging/v1.10-regolith",
+      "ref": "packaging/v1.11-regolith",
       "source": "https://github.com/regolith-linux/sway-regolith.git"
     }
   }


### PR DESCRIPTION
Wanted to test the changes from sway 1.11 in resolute and debian testing. This should ideally add the package to unstable stage. The upstream sway package has 1.11 published for these releases.

REF: https://github.com/regolith-linux/sway-regolith/pull/38